### PR TITLE
tal now uses .metta as a storage path for runtime files

### DIFF
--- a/mirantis/testing/metta_kubernetes/helm_workload.py
+++ b/mirantis/testing/metta_kubernetes/helm_workload.py
@@ -83,13 +83,11 @@ class KubernetesHelmWorkloadPlugin(WorkloadBase):
 
         values = workload_config.get(
             [self.config_base, KUBERNETES_HELM_WORKLOAD_CONFIG_KEY_VALUES], exception_if_missing=False)
-
         if values is None:
             values = {}
 
         repos_config = workload_config.get(
             [self.config_base, KUBERNETES_HELM_WORKLOAD_CONFIG_KEY_REPOS], exception_if_missing=False)
-
         if repos_config is None:
             repos_config = {}
 

--- a/mirantis/testing/metta_launchpad/launchpad.py
+++ b/mirantis/testing/metta_launchpad/launchpad.py
@@ -95,7 +95,8 @@ class LaunchpadClient:
 
     def reset(self):
         """ Uninstall using the launchpad client """
-        self._run(['reset'])
+        if os.path.isfile(self.config_file):
+            self._run(['reset', '--force'])
 
     def register(self, name: str, email: str, company: str):
         """ Uninstall using the launchpad client """

--- a/mirantis/testing/metta_mirantis/config/variation/tal/fixtures.yml
+++ b/mirantis/testing/metta_mirantis/config/variation/tal/fixtures.yml
@@ -47,7 +47,7 @@ launchpad:
     # the example tf plans need launchpad to run in the plan root
     working_dir: "{variables:terraform_plan}"
     # put the launchpad yml file in the project folder
-    config_file: "{variables:files_path}/launchpad/{variables:files_prefix}.yaml"
+    config_file: "{variables:files_path}/.metta/{variables:files_prefix}.yaml"
 
 # Here we use a combo provisioner with  a high priority to act as a primary
 # provisioner to manage all of the others

--- a/mirantis/testing/metta_mirantis/config/variation/tal/terraform.yml
+++ b/mirantis/testing/metta_mirantis/config/variation/tal/terraform.yml
@@ -15,10 +15,10 @@ plan:
     type: local
     path: "{variables:terraform_plan}"
 state:
-    path: "{variables:files_path?.}/terraform/{variables:files_prefix}.terraform.state"
+    path: "{variables:files_path?.}/.metta/{variables:files_prefix}.terraform.state"
 
 # Where will the vars be written
-vars_path: "{variables:files_path?.}/terraform/{variables:files_prefix}.tfvars.json"
+vars_path: "{variables:files_path?.}/.metta/{variables:files_prefix}.tfvars.json"
 # Vars list for terraform
 vars:
     # description = "Name used to identify resources and passed to launchpad."

--- a/suites/sanity/.gitignore
+++ b/suites/sanity/.gitignore
@@ -1,4 +1,2 @@
-terraform
-launchpad
-ssh
+.metta
 __pycache__

--- a/suites/upgrade/.gitignore
+++ b/suites/upgrade/.gitignore
@@ -1,4 +1,2 @@
-terraform
-launchpad
-ssh
+.metta
 __pycache__


### PR DESCRIPTION
- also fixed launchpad reset

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>