### PR TITLE
fix helm subprocess missing env

### DIFF
--- a/demos/dummy/README.md
+++ b/demos/dummy/README.md
@@ -1,0 +1,74 @@
+# Dummy metta
+
+This is a pytest test suite which can be used to test overall metta workflows
+without any network/cluster resources being used.
+
+The test suite is centered around the metta_dummy plugins, which are usable for
+mocking and debugging.
+
+Use this if you are curious about some core plumbing and want to see what happens
+when you change things.  It is fast and breakign it has no real impact.
+
+## Environment
+
+A single environment called `dummy` is defined in `./config/environemnt.yml`.  
+Fixtures are loaded directly from `fixtures.yml` (as directed in the env config)
+
+## Fixtures
+
+This suite creates fixtures only for the purpose of running tests, and is not
+trying to make fixtures that make sense for all testing scenarios.  That said
+it does try to run some standard workflow to confirm that the metta plumbing
+works.
+
+## Plugins
+
+Dummy plugins meet the interface expectations of their implementation but really
+they do nothing other than return a configured set of fixtures themselves and
+run logging events as needed.
+
+In general, the end result of the fixtures is that a fixtures.get_plugin() call
+will be run, and output plugins will be checked for proper output.
+
+It should be clear that you can use dummy plugins to mock any other plugin by
+programming it with the required fixtures list.
+
+## Usage
+
+### Pytest
+
+The setup should be good to go if you get the requirements installed.  You
+should be able to run pytest as normal.
+
+You will need to have the metta package, and pytest (and pytest-order) installed
+to run this pytest suite.
+
+You will need some AWS credentials in scope, then just run the following in
+the project root:
+
+```
+$/> pytest -s
+```
+
+(you can use the `python -m pytest -s` approach as well.)
+
+You can see the approach to fixtures in `conftest.py`.  There we have two
+provisioner fixtures used to retrieve the metta environment objects. Each
+fixture factory will first check to see if the environment has been provisioned,
+and if not it will do so.
+
+You will need to make sure that you don't run any tests using the "before"
+environment after the "after" environment, as using the latter will run the
+after provisioning.
+
+### Cli
+
+You will need the metta package installed, and AWS credentials will be needed
+for the terraform provisioning step.
+
+There is a python setuptools entrypoint `metta` which you can use to interact
+with the metta plugins directly for debugging and management. This should have
+been installed when you installed metta itself.
+
+This executable will recognize your environment if it finds a metta.yml file and
+will allow you to inspect the metta configuration, and environment in detail in

--- a/mirantis/testing/metta_kubernetes/helm_workload.py
+++ b/mirantis/testing/metta_kubernetes/helm_workload.py
@@ -179,6 +179,7 @@ class KubernetesHelmV3WorkloadInstance:
                 " ".join(cmd))
             exec = subprocess.run(
                 cmd,
+                env=env,
                 cwd=self.working_dir,
                 shell=False,
                 stdout=subprocess.PIPE)
@@ -187,5 +188,5 @@ class KubernetesHelmV3WorkloadInstance:
         else:
             logger.debug("running launchpad command: %s", " ".join(cmd))
             exec = subprocess.run(
-                cmd, cwd=self.working_dir, check=True, text=True)
+                cmd, env=env,cwd=self.working_dir, check=True, text=True)
             exec.check_returncode()

--- a/mirantis/testing/metta_launchpad/README.md
+++ b/mirantis/testing/metta_launchpad/README.md
@@ -1,0 +1,1 @@
+# Launchpad

--- a/mirantis/testing/metta_launchpad/launchpad.py
+++ b/mirantis/testing/metta_launchpad/launchpad.py
@@ -121,6 +121,8 @@ class LaunchpadClient:
         client_bundle_path = self._mke_client_bundle_path(user)
         client_bundle_meta_file = os.path.join(
             client_bundle_path, METTA_USER_LAUNCHPAD_BUNDLE_META_FILE)
+        client_bundle_kubeconfig_file = os.path.join(
+            client_bundle_path, 'kube.yml')
 
         if reload or not os.path.isfile(client_bundle_meta_file):
 
@@ -146,13 +148,14 @@ class LaunchpadClient:
         try:
             with open(client_bundle_meta_file) as json_file:
                 data = json.load(json_file)
+                # helm complains if this file has loose permissions
+                os.chmod(client_bundle_kubeconfig_file, 0o600)
         except FileNotFoundError as e:
             raise ValueError(
                 "failed to open the launchpad client bundle meta file.") from e
 
         # Not sure why this isn't in there:
-        data['Endpoints']['kubernetes']['kubeconfig'] = os.path.join(
-            client_bundle_path, 'kube.yml')
+        data['Endpoints']['kubernetes']['kubeconfig'] = client_bundle_kubeconfig_file
         # add some stuff that a client bundle always has
         data['path'] = client_bundle_path
         data['modified'] = datetime.datetime.fromtimestamp(

--- a/mirantis/testing/metta_mirantis/config/variation/tal/fixtures.yml
+++ b/mirantis/testing/metta_mirantis/config/variation/tal/fixtures.yml
@@ -7,7 +7,7 @@ terraform:
     # Terraform will configure itself from the ./terraform.yml file
     # This is actually its default but this demonstrates that we have
     # the option.
-    arguments:
+    from_config:
         label: terraform
         # base: some.path.in.the.file
 
@@ -16,8 +16,10 @@ ansible:
     type: metta.plugin.provisioner
     plugin_id: metta_ansible
 
-    # Pass these values to the provisioner constructor.
-    arguments:
+    # The ansible plugin is setup to pull config from a label/base pair, but
+    # as it currently doesn't do anything, it is just pointed to pull directly
+    # this files.  No need for an ansible file.
+    from_config:
         label: fixtures
         base: ansible
 
@@ -28,26 +30,9 @@ launchpad:
 
     # Pass these values to the provisioner constructor.  The launchpad
     # constructor accepts override for "where to get config".  The values
-    # here tell it to look back in this same location for config, instead of
-    # its default of looking in the ./launchpad.yml file
-    arguments:
-        label: fixtures
-        base: launchpad
-
-    # Declare which output from the environment will give us our launchpad yml
-    # The output needs to exist by the time the launchpad provisioner .apply()
-    # runs.
-    source_output:
-      instance_id: mke_cluster
-
-    cli-options:
-        accept-license: true
-        disable-telemetry: true
-
-    # the example tf plans need launchpad to run in the plan root
-    working_dir: "{variables:terraform_plan}"
-    # put the launchpad yml file in the project folder
-    config_file: "{variables:files_path}/.metta/{variables:files_prefix}.yaml"
+    # here tell it to look in the launchpad.yml
+    from_config:
+        label: launchpad
 
 # Here we use a combo provisioner with  a high priority to act as a primary
 # provisioner to manage all of the others
@@ -56,17 +41,15 @@ launchpad:
 #   so make sure that it comes last in creation
 # @NOTE you probably want this plugin to be a higher priority than the others
 #   so that a get_plugins)provisioner) retreives this one first.
-# combo_provisioner:
-#     type: metta.plugin.provisioner
-#     plugin_id: combo
-#     priority: 95
-#
-#     arguments:
-#       # tell the plugin to load config from "here"
-#       label: fixtures
-#       base: combo_provisioner
-#
-#     backends:
-#     - instance_id: terraform
-#     - instance_id: ansible
-#     - instance_id: launchpad
+combo_provisioner:
+    type: metta.plugin.provisioner
+    plugin_id: combo
+    priority: 95
+
+    # tell the plugin to load config from "here"
+    from_config: true
+
+    backends:
+    - instance_id: terraform
+    - instance_id: ansible
+    - instance_id: launchpad

--- a/mirantis/testing/metta_mirantis/config/variation/tal/launchpad.yml
+++ b/mirantis/testing/metta_mirantis/config/variation/tal/launchpad.yml
@@ -1,0 +1,14 @@
+# Declare which output from the environment will give us our launchpad yml
+# The output needs to exist by the time the launchpad provisioner .apply()
+# runs.
+source_output:
+    instance_id: mke_cluster
+
+cli-options:
+    accept-license: true
+    disable-telemetry: true
+
+# the example tf plans need launchpad to run in the plan root
+working_dir: "{variables:terraform_plan}"
+# put the launchpad yml file in the project folder
+config_file: "{variables:files_path}/{variables:files_prefix}.launchpad.yaml"

--- a/mirantis/testing/metta_mirantis/config/variation/tal/terraform.yml
+++ b/mirantis/testing/metta_mirantis/config/variation/tal/terraform.yml
@@ -3,10 +3,6 @@
 # but terraform will perform that 'backend' provisioner role.
 # Look in the fixtures.yml for the defined provisioner.
 
-
-# This file is not used for launchpad clusters.  look in launchpad.yml backend:
-plugin_id: metta_terraform
-
 # everythion below here is consumed by the terraform provider plugin
 # as though this were the contents of ./terraform.yml
 
@@ -15,10 +11,10 @@ plan:
     type: local
     path: "{variables:terraform_plan}"
 state:
-    path: "{variables:files_path?.}/.metta/{variables:files_prefix}.terraform.state"
+    path: "{variables:files_path?.}/{variables:files_prefix}.terraform.state"
 
 # Where will the vars be written
-vars_path: "{variables:files_path?.}/.metta/{variables:files_prefix}.tfvars.json"
+vars_path: "{variables:files_path?.}/{variables:files_prefix}.tfvars.json"
 # Vars list for terraform
 vars:
     # description = "Name used to identify resources and passed to launchpad."
@@ -148,11 +144,4 @@ vars:
     #     - ""
 
     # description = "If non-empty, use this path/filename as the ssh key file instead of generating automatically."
-    ssh_key_file_path: "{variables:files_path?.}/terraform/{variables:files_prefix}.pem"
-
-
-cli-options:
-accept-license: true
-disable-telemetry: true
-
-config_file: "{variables:files_path}/launchpad/{variables:files_prefix}.yaml"
+    ssh_key_file_path: "{variables:files_path?.}/{variables:files_prefix}.host.pem"

--- a/suites/sanity/config/variables.yml
+++ b/suites/sanity/config/variables.yml
@@ -18,9 +18,10 @@ project: "PRODENG"
 
 # A generic project/user id that we reuse across the configuration
 id: "{user}-sanity"
-# where the ltc variation should keep runtime paths like terraform state
-files_path: "{paths:project}"
-# Prefix all resource files we create with this, which allows multiples and id
+# where the tal variation should keep runtime paths like terraform state
+files_path: "{paths:project}/.metta"
+# Prefix all resource files we create with this, which allows different environments 
+# to have their resource files in the same place
 files_prefix: "{id}"
 # Prefix all created resources with this so that we can id them
 # this is different than {id} to allow character limits to be avoided

--- a/suites/sanity/tests/test_k8s_clients.py
+++ b/suites/sanity/tests/test_k8s_clients.py
@@ -46,7 +46,7 @@ def test_kubernetes_deployment_workload(environment_up):
     print(status)
 
 
-def test_kubernetes_help_workload(environment_up):
+def test_kubernetes_helm_workload(environment_up):
     """ test that we can get a helm workload to run """
 
     metrics_helm_workload = environment_up.fixtures.get_plugin(type=Type.WORKLOAD,

--- a/suites/upgrade/config/variables.yml
+++ b/suites/upgrade/config/variables.yml
@@ -19,7 +19,7 @@ project: "PRODENG"
 # A generic project/user id that we reuse across the configuration
 id: "{user}-upgrade"
 # where the ltc variation should keep runtime paths like terraform state
-files_path: "{paths:project}"
+files_path: "{paths:project}/.metta"
 # Prefix all resource files we create with this, which allows multiples and id
 files_prefix: "{id}"
 # Prefix all created resources with this so that we can id them


### PR DESCRIPTION
- this fixes kubeconfig assingment

ALSO
- launchpad config is back to its own file for tal
- some other tal rewiring to fix file locations
- some more docs

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>