### PR TITLE
fix launchpad exec which doen't like args

### DIFF
--- a/mirantis/testing/metta_launchpad/launchpad.py
+++ b/mirantis/testing/metta_launchpad/launchpad.py
@@ -269,10 +269,11 @@ class LaunchpadClient:
 
         cmd += args
 
-        if self.disable_telemetry:
-            cmd += ['--disable-telemetry']
-        if self.accept_license:
-            cmd += ['--accept-license']
+        if not args[0] in ['exec']:
+            if self.disable_telemetry:
+                cmd += ['--disable-telemetry']
+            if self.accept_license:
+                cmd += ['--accept-license']
 
         if return_output:
             logger.debug(

--- a/suites/clients/config/environments.yml
+++ b/suites/clients/config/environments.yml
@@ -1,6 +1,6 @@
 
-# Create an environment called 'sanity'
-sanity:
+# Create an environment called 'clients'
+clients:
   bootstraps:
     metta:
     - metta_common


### PR DESCRIPTION
- exec advertises that it accepts --accept-license and
--disable-telemetry but it does not.

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>