### PR TITLE
drop ansible from suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ harnesses to test against.
 
 ## Dependencies
 
-### Configurus
+Metta relies heavily on python 3.8 features and setuptools for the 
+modular plugin system.
+
+### Configerus
 
 Configerus is heavily leveraged for dynamic and abstracted configuration.
 

--- a/suites/altrepo/conftest.py
+++ b/suites/altrepo/conftest.py
@@ -41,9 +41,6 @@ def environment_up(environment):
     launchpad = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='launchpad')
 
-    ansible = environment.fixtures.get_plugin(
-        type=Type.PROVISIONER, instance_id='ansible')
-
     terraform = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='terraform')
 
@@ -59,7 +56,6 @@ def environment_up(environment):
         try:
             logger.info("Preparing the testing cluster using the provisioner")
             terraform.prepare()
-            ansible.prepare()
         except Exception as e:
             logger.error("Provisioner failed to init: %s", e)
             raise e
@@ -67,7 +63,6 @@ def environment_up(environment):
             logger.info(
                 "Starting up the testing cluster using the provisioner")
             terraform.apply()
-            ansible.apply()
             launchpad.apply()
         except Exception as e:
             logger.error("Provisioner failed to start: %s", e)

--- a/suites/chaos/config/environments.yml
+++ b/suites/chaos/config/environments.yml
@@ -4,7 +4,6 @@ chaos:
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform

--- a/suites/chaos/conftest.py
+++ b/suites/chaos/conftest.py
@@ -41,9 +41,6 @@ def environment_up(environment):
     launchpad = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='launchpad')
 
-    ansible = environment.fixtures.get_plugin(
-        type=Type.PROVISIONER, instance_id='ansible')
-
     terraform = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='terraform')
 
@@ -59,7 +56,6 @@ def environment_up(environment):
         try:
             logger.info("Preparing the testing cluster using the provisioner")
             terraform.prepare()
-            ansible.prepare()
         except Exception as e:
             logger.error("Provisioner failed to init: %s", e)
             raise e
@@ -67,7 +63,6 @@ def environment_up(environment):
             logger.info(
                 "Starting up the testing cluster using the provisioner")
             terraform.apply()
-            ansible.apply()
             launchpad.apply()
         except Exception as e:
             logger.error("Provisioner failed to start: %s", e)

--- a/suites/clients/config/environments.yml
+++ b/suites/clients/config/environments.yml
@@ -4,7 +4,6 @@ clients:
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform

--- a/suites/clients/conftest.py
+++ b/suites/clients/conftest.py
@@ -41,9 +41,6 @@ def environment_up(environment):
     launchpad = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='launchpad')
 
-    ansible = environment.fixtures.get_plugin(
-        type=Type.PROVISIONER, instance_id='ansible')
-
     terraform = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='terraform')
 
@@ -59,7 +56,6 @@ def environment_up(environment):
         try:
             logger.info("Preparing the testing cluster using the provisioner")
             terraform.prepare()
-            ansible.prepare()
         except Exception as e:
             logger.error("Provisioner failed to init: %s", e)
             raise e
@@ -67,7 +63,6 @@ def environment_up(environment):
             logger.info(
                 "Starting up the testing cluster using the provisioner")
             terraform.apply()
-            ansible.apply()
             launchpad.apply()
         except Exception as e:
             logger.error("Provisioner failed to start: %s", e)

--- a/suites/cncf/config/environments.yml
+++ b/suites/cncf/config/environments.yml
@@ -21,7 +21,6 @@
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform
@@ -63,7 +62,6 @@
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform
@@ -112,7 +110,6 @@
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform

--- a/suites/cncf/conftest.py
+++ b/suites/cncf/conftest.py
@@ -39,6 +39,7 @@ def environment_up(environment):
     """
 
     provisioner = environment.fixtures.get_plugin(type=Type.PROVISIONER)
+    """ combo provisioner """
 
     # We will use this config to make decisions about what we need to create
     # and destroy for this environment up.

--- a/suites/cross-version/config/envbuilder.yml
+++ b/suites/cross-version/config/envbuilder.yml
@@ -86,7 +86,6 @@ base:
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform

--- a/suites/upgrade/config/environments.yml
+++ b/suites/upgrade/config/environments.yml
@@ -19,7 +19,6 @@ upgrade:
   bootstraps:
     metta:
     - metta_common
-    - metta_ansible
     - metta_docker
     - metta_kubernetes
     - metta_terraform

--- a/suites/upgrade/conftest.py
+++ b/suites/upgrade/conftest.py
@@ -75,9 +75,6 @@ def environment_up(environment):
     launchpad = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='launchpad')
 
-    ansible = environment.fixtures.get_plugin(
-        type=Type.PROVISIONER, instance_id='ansible')
-
     terraform = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='terraform')
 
@@ -88,7 +85,6 @@ def environment_up(environment):
         try:
             logger.info("Preparing the testing cluster using the provisioner")
             terraform.prepare()
-            ansible.prepare()
             launchpad.prepare()
         except Exception as e:
             logger.error("Provisioner failed to init: %s", e)
@@ -97,7 +93,6 @@ def environment_up(environment):
             logger.info(
                 "Starting up the testing cluster using the provisioner")
             terraform.apply()
-            ansible.apply()
             launchpad.apply()
         except Exception as e:
             logger.error("Provisioner failed to start: %s", e)
@@ -153,9 +148,6 @@ def environment_down(environment):
     launchpad = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='launchpad')
 
-    ansible = environment.fixtures.get_plugin(
-        type=Type.PROVISIONER, instance_id='ansible')
-
     terraform = environment.fixtures.get_plugin(
         type=Type.PROVISIONER, instance_id='terraform')
 
@@ -166,7 +158,6 @@ def environment_down(environment):
             logger.info(
                 "Stopping the test cluster using the provisioner as directed by config")
             launchpad.destroy()
-            ansible.destroy()
             terraform.destroy()
         except Exception as e:
             logger.error("Provisioner failed to stop: %s", e)


### PR DESCRIPTION
- ansible provisioner currently doesn't do anything so it can be left
out of the suites

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>