### PR TITLE
cncf:suite delay before start

### DIFF
--- a/suites/dev/altrepo/Jenkinsfile.groovy
+++ b/suites/dev/altrepo/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/dev/chaos/Jenkinsfile.groovy
+++ b/suites/dev/chaos/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/dev/testkit/Jenkinsfile
+++ b/suites/dev/testkit/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/dev/testkit/Jenkinsfile.groovy
+++ b/suites/dev/testkit/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/clients/Jenkinsfile.groovy
+++ b/suites/stable/clients/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/cncf/Jenkinsfile.groovy
+++ b/suites/stable/cncf/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/cncf/conftest.py
+++ b/suites/stable/cncf/conftest.py
@@ -1,13 +1,14 @@
 """
 
-PyTest setup for test suite
+PyTest setup for test suite.
 
-Primarily used to define fixtures used for the pytest implementation, which are then consumed by
-the test cases themselved.
+Primarily used to define fixtures used for the pytest implementation, which are
+then consumed by the test cases themselved.
 
-We realy heavily on metta discovery which looks for the metta.yml file, and uses that to interpret
-the config folder to define metta infrastructure.  The same approach is used by the metta cli,
-which makes the cli quite usable in this scope
+We realy heavily on metta discovery which looks for the metta.yml file, and
+uses that to interpret the config folder to define metta infrastructure.  The
+same approach is used by the metta cli, which makes the cli quite usable in
+this scope.
 
 """
 import logging
@@ -32,7 +33,7 @@ logger = logging.getLogger('pytest-conftest')
 
 @pytest.fixture(scope='session')
 def environment_discover():
-    """ discover the metta environments """
+    """Discover the metta environments."""
     # Tell metta to scan for automatic configuration of itself.
     # It starts my looking in paths upwards for a 'metta.yml' file; if it finds
     # one then it uses that path as a root source of config
@@ -41,7 +42,7 @@ def environment_discover():
 
 @pytest.fixture(scope='session')
 def environment(environment_discover) -> Environment:
-    """ get the metta environment """
+    """Get the metta environment."""
     # we don't use the discover fixture, we just need it to run first
     # we don't pass an environment name, which gives us the default environment
     return get_environment()
@@ -49,25 +50,24 @@ def environment(environment_discover) -> Environment:
 
 @pytest.fixture(scope='session')
 def environment_up(environment: Environment) -> Environment:
-    """ get the environment but start the provisioners before returning
+    """Get the environment but start the provisioners before returning.
 
     This is preferable to the raw provisioner in cases where you want a running
     cluster so that the cluster startup cost does not get reflected in the
     first test case which uses the fixture.  Also it can tear itself down
 
-    You can still use the provsioners to update the resources if the provisioner
-    plugins can handle it.
+    You can still use the provsioners to update the resources if the
+    provisioner plugins can handle it.
 
 
-    In this function, we know which provisioners we want to use, and we use them
-    in an order which makes sense to use.  We could just use the metta_common
-    combo provisioner, which combines multiple provisioners into one.
+    In this function, we know which provisioners we want to use, and we use
+    them in an order which makes sense to use.  We could just use the
+    metta_common combo provisioner, which combines multiple provisioners into
+    one.
 
     """
-
     launchpad = environment.fixtures.get_plugin(plugin_type=METTA_PLUGIN_TYPE_PROVISIONER,
                                                 plugin_id=METTA_LAUNCHPAD_PROVISIONER_PLUGIN_ID)
-
     terraform = environment.fixtures.get_plugin(plugin_type=METTA_PLUGIN_TYPE_PROVISIONER,
                                                 plugin_id=METTA_TERRAFORM_PROVISIONER_PLUGIN_ID)
 

--- a/suites/stable/cncf/tests/test_cncf_conformance.py
+++ b/suites/stable/cncf/tests/test_cncf_conformance.py
@@ -5,6 +5,7 @@ Test that some clients work
 """
 import time
 import logging
+import pytest
 
 from mirantis.testing.metta.workload import METTA_PLUGIN_TYPE_WORKLOAD
 
@@ -21,27 +22,45 @@ SONOBUOY_TEST_TIMER_STEP = 10
 """ check status every X seconds """
 
 
-def test_cncf_conformance(environment_up):
-    """ run cncf conformance test suite """
+# impossible to chain pytest fixtures without using the same names
+# pylint: disable=redefined-outer-name
 
-    cncf = environment_up.fixtures.get_plugin(plugin_type=METTA_PLUGIN_TYPE_WORKLOAD,
+
+@pytest.fixture(scope="module")
+def cncf_workload(environment_up):
+    """Retrieve the CNCF workload instance."""
+
+    # if we don't put in a small delay then we get an error out of sonobuoy:
+    # e2e: Can't schedule pod: 0/1 nodes are available: 1 node(s) had taint \
+    #      {com.docker.ucp.manager: }, that the pod didn't tolerate. \
+    #      (errors/global/error.json)
+    #
+    # This error goes away with a short delay.
+
+    return environment_up.fixtures.get_plugin(plugin_type=METTA_PLUGIN_TYPE_WORKLOAD,
                                               plugin_id=METTA_PLUGIN_ID_SONOBUOY_WORKLOAD,
                                               instance_id='cncf')
-    """ cncf workload plugin (the instance_id matches our config/fixtures.yml key)"""
 
-    instance = cncf.create_instance(environment_up.fixtures)
 
+@pytest.fixture()
+def cncf_workload_instance(environment_up, cncf_workload):
+    """Retrieve an individual worload instance from the cncf plugin."""
+    return cncf_workload.create_instance(environment_up.fixtures)
+
+
+def test_cncf_conformance(cncf_workload_instance):
+    """ run cncf conformance test suite """
     try:
         # start the CNCF conformance run
         logger.info("Starting sonobuoy run")
-        instance.apply(wait=True)
+        cncf_workload_instance.apply(wait=True)
         logger.debug("Sonobuoy started, waiting for finish")
 
         # Every X seconds output some status report to show that it is still
         # working
         for i in range(0, round(SONOBUOY_TEST_TIMER_LIMIT /
                                 SONOBUOY_TEST_TIMER_STEP)):
-            status = instance.status()
+            status = cncf_workload_instance.status()
 
             if status is not None:
                 for plugin_id in SONOBUOY_TEST_INTERESTING_PLUGINS:
@@ -50,7 +69,8 @@ def test_cncf_conformance(environment_up):
                         break
 
                     logger.debug("%s:: Checking %s:%s",
-                                 i * SONOBUOY_TEST_TIMER_STEP, plugin_id, status.plugin(plugin_id))
+                                 i * SONOBUOY_TEST_TIMER_STEP, plugin_id,
+                                 status.plugin(plugin_id))
                 else:
                     break
 
@@ -60,7 +80,7 @@ def test_cncf_conformance(environment_up):
             logger.info("sonobuoy tick")
             time.sleep(SONOBUOY_TEST_TIMER_STEP)
 
-        results = instance.retrieve()
+        results = cncf_workload_instance.retrieve()
 
         no_errors = True
         for plugin_id in SONOBUOY_TEST_INTERESTING_PLUGINS:
@@ -76,4 +96,4 @@ def test_cncf_conformance(environment_up):
             raise RuntimeError("Sonobuoy encountered an error")
 
     finally:
-        instance.destroy(wait=True)
+        cncf_workload_instance.destroy(wait=True)

--- a/suites/stable/crossversion/Jenkinsfile.groovy
+++ b/suites/stable/crossversion/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/npods/Jenkinsfile.groovy
+++ b/suites/stable/npods/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/sanity/Jenkinsfile.groovy
+++ b/suites/stable/sanity/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 

--- a/suites/stable/upgrade/Jenkinsfile.groovy
+++ b/suites/stable/upgrade/Jenkinsfile.groovy
@@ -103,7 +103,7 @@ pipeline {
                                                     metta config get metta > metta.config.metta.json
                                                     metta config get environment > metta.config.environment.json
                                                     metta config get variables > metta.config.variables.json
-                                                    metta fixtures info --deep > metta.fixtures.json
+                                                    metta fixture info --deep > metta.fixtures.json
                                                 """
                                             )
 


### PR DESCRIPTION
- delay avoids error about ucp taint
- also refactor cncf for fixtures
- also some Jenkinsfile fixes for metta error handling

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>