### PR TITLE
fixtures can now be labelled by factory and conf

### DIFF
--- a/mirantis/testing/metta_ansible/__init__.py
+++ b/mirantis/testing/metta_ansible/__init__.py
@@ -39,9 +39,7 @@ from .cli import AnsibleCliPlugin, METTA_ANSIBLE_CLI_PLUGIN_ID
 
 @Factory(
     plugin_id=METTA_ANSIBLE_ANSIBLECLIPLAYBOOK_PROVISIONER_PLUGIN_ID,
-    interfaces=[
-        METTA_PLUGIN_INTERFACE_ROLE_PROVISIONER,
-    ],
+    interfaces=[METTA_PLUGIN_INTERFACE_ROLE_PROVISIONER],
 )
 def metta_plugin_factory_provisioner_ansibleplaybook(
     environment: Environment,

--- a/mirantis/testing/metta_ansible/cli.py
+++ b/mirantis/testing/metta_ansible/cli.py
@@ -6,7 +6,6 @@ Comamnds for itneracting with the ansible plugins, primarily the provisioner
 
 """
 import logging
-from typing import List
 
 from mirantis.testing.metta.environment import Environment
 from mirantis.testing.metta.healthcheck import Health

--- a/mirantis/testing/metta_cli/fixtures.py
+++ b/mirantis/testing/metta_cli/fixtures.py
@@ -35,16 +35,18 @@ class FixturesGroup:
         """Attach environment to object."""
         self._environment = environment
 
+    # pylint: disable=too-many-arguments
     def _filter(
         self,
         plugin_id: str = "",
         instance_id: str = "",
         interfaces: List[str] = None,
+        labels: List[str] = None,
         skip_cli_plugins: bool = True,
     ):
         """Filter fixtures centrally."""
         matches = self._environment.fixtures.filter(
-            plugin_id=plugin_id, instance_id=instance_id, interfaces=interfaces
+            plugin_id=plugin_id, instance_id=instance_id, interfaces=interfaces, labels=labels
         )
         """All matching filtered fixtures."""
 
@@ -63,6 +65,7 @@ class FixturesGroup:
     def plugins(
         self,
         interface: str = "",
+        label: str = "",
         skip_cli_plugins: bool = True,
     ):
         """List registered plugins and interfaces."""
@@ -76,10 +79,13 @@ class FixturesGroup:
 
             if interface and interface not in registration.interfaces:
                 continue
+            if label and label not in registration.labels:
+                continue
 
             plugins_info[registration.plugin_id] = {
                 "plugin_id": registration.plugin_id,
                 "interfaces": registration.interfaces,
+                "labels_from_factory": registration.labels,
             }
 
         return cli_output(plugins_info)
@@ -93,6 +99,7 @@ class FixturesGroup:
         plugin_id: str = "",
         instance_id: str = "",
         interface: str = "",
+        label: str = "",
         skip_cli_plugins: bool = True,
     ):
         """Return Info for fixtures."""
@@ -101,6 +108,7 @@ class FixturesGroup:
             plugin_id=plugin_id,
             instance_id=instance_id,
             interfaces=[interface] if interface else [],
+            labels=[label] if label else [],
             skip_cli_plugins=skip_cli_plugins,
         ):
             fixture_info_list.append(fixture.info(deep=deep, children=children))

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     fire
     requests
     toml
-    ansible
 
 [options.entry_points]
 console_scripts=

--- a/suites/dev/ansible_smoke/config/fixtures.yml
+++ b/suites/dev/ansible_smoke/config/fixtures.yml
@@ -48,6 +48,8 @@ healthpoller:
 
 ansibledebug:
   plugin_id: metta_ansible_clicore_ansibleplaybook_workload
+  labels:
+    primary: True
 
   # tell the plugin to load config from "here"
   from_config: true


### PR DESCRIPTION
- fixtures now have a dict of labels
- fixture labels can come in the factory registration
- fixture labels can be overridden from creation/config

Also
- also removed the pip ansible dependency as it is a
  big import for something we aren't strictly using.

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>